### PR TITLE
PERP-4071 | Fix withdraw all

### DIFF
--- a/frontend/src/utils/tokens.ts
+++ b/frontend/src/utils/tokens.ts
@@ -23,6 +23,7 @@ import usdcLogo from '@assets/tokens/usdc-logo.svg'
 
 import { formatToSignificantDigits, unitsToValue, valueToUnits } from '@utils/number'
 
+BigNumber.config({ ROUNDING_MODE: BigNumber.ROUND_DOWN })
 export const SIGNIFICANT_DIGITS = 5
 
 export interface TokenConfig {


### PR DESCRIPTION
@lvn-rusty-dragon this effectively fixes the issue (and it's the same thing we're doing in the Gov site), but there's a different issue I'm not sure how to approach. It's because of the huge precision that the "tokens" have - I think it's like 18 decimal places. Right now the frontend is capping them to 3 decimal places, but that in combination with rounding down, will make it so that there's always some amount of tokens left unable to be withdrawn.