### PR TITLE
Total wallets respects the LP shares

### DIFF
--- a/contract/src/cpmm.rs
+++ b/contract/src/cpmm.rs
@@ -28,9 +28,17 @@ impl AddLiquidity {
         } else {
             lp
         };
+        if lp.is_zero() {
+            return Ok(());
+        }
         market.lp_shares += lp;
         let mut share_info = ShareInfo::load(storage, market, sender)?
             .unwrap_or_else(|| ShareInfo::new(market.outcomes.len()));
+
+        if share_info.shares.is_zero() {
+            market.lp_wallets += 1;
+        }
+
         share_info.shares += lp;
 
         let mut had_tokens = false;

--- a/contract/src/execute.rs
+++ b/contract/src/execute.rs
@@ -233,6 +233,9 @@ fn deposit(
     if !lp.is_zero() {
         if share_info.shares.is_zero() {
             market.lp_wallets += 1;
+            if !share_info.has_tokens() {
+                market.total_wallets += 1;
+            }
         }
         share_info.shares += lp;
     }

--- a/contract/src/execute.rs
+++ b/contract/src/execute.rs
@@ -170,9 +170,10 @@ fn add_market(
         withdrawal_stop_date,
         winner: None,
         house,
+        lp_shares,
         // Always have 1 wallet: the house
         total_wallets: 1,
-        lp_shares,
+        lp_wallets: 1,
     };
     MARKETS.save(deps.storage, id, &market)?;
 
@@ -225,7 +226,12 @@ fn deposit(
 
     assert_eq!(share_info.outcomes.len(), market.outcomes.len());
 
-    share_info.shares += lp;
+    if !lp.is_zero() {
+        if share_info.shares.is_zero() {
+            market.lp_wallets += 1;
+        }
+        share_info.shares += lp;
+    }
 
     let had_any_tokens = share_info.has_tokens() || !share_info.shares.is_zero();
 

--- a/contract/src/execute.rs
+++ b/contract/src/execute.rs
@@ -170,11 +170,8 @@ fn add_market(
         withdrawal_stop_date,
         winner: None,
         house,
-        total_wallets: if returned.iter().any(|token| !token.is_zero()) {
-            1
-        } else {
-            0
-        },
+        // Always have 1 wallet: the house
+        total_wallets: 1,
         lp_shares,
     };
     MARKETS.save(deps.storage, id, &market)?;
@@ -230,7 +227,7 @@ fn deposit(
 
     share_info.shares += lp;
 
-    let had_any_tokens = share_info.has_tokens();
+    let had_any_tokens = share_info.has_tokens() || !share_info.shares.is_zero();
 
     let outcome_tokens = share_info.get_outcome_mut(id, outcome).unwrap();
     let had_these_tokens = !outcome_tokens.is_zero();
@@ -341,7 +338,7 @@ fn withdraw(
     if share_info.get_outcome(&market, outcome, false)?.is_zero() {
         println!("here1");
         market.get_outcome_mut(outcome)?.wallets -= 1;
-        if !share_info.has_tokens() {
+        if !share_info.has_tokens() && share_info.shares.is_zero() {
             market.total_wallets -= 1;
         }
     }

--- a/contract/src/sanity.rs
+++ b/contract/src/sanity.rs
@@ -20,6 +20,7 @@ pub fn sanity(store: &dyn Storage, env: &Env) {
                 house,
                 total_wallets,
                 lp_shares,
+                lp_wallets,
             },
         ) = market.unwrap();
 
@@ -42,6 +43,7 @@ pub fn sanity(store: &dyn Storage, env: &Env) {
             .collect::<Vec<_>>();
         let mut computed_shares = LpShare::zero();
         let mut computed_total_wallets = 0;
+        let mut computed_lp_wallets = 0;
         let mut computed_wallets = std::iter::repeat(0)
             .take(market_outcomes.len())
             .collect::<Vec<_>>();
@@ -76,6 +78,10 @@ pub fn sanity(store: &dyn Storage, env: &Env) {
             if has_tokens || !shares.is_zero() {
                 computed_total_wallets += 1;
             }
+
+            if !shares.is_zero() {
+                computed_lp_wallets += 1;
+            }
         }
 
         assert_eq!(computed_shares, lp_shares);
@@ -84,6 +90,7 @@ pub fn sanity(store: &dyn Storage, env: &Env) {
         }
 
         assert_eq!(computed_total_wallets, total_wallets);
+        assert_eq!(computed_lp_wallets, lp_wallets);
 
         for outcome in &market_outcomes {
             assert_eq!(computed_wallets[outcome.id.usize()], outcome.wallets);

--- a/contract/src/sanity.rs
+++ b/contract/src/sanity.rs
@@ -73,7 +73,7 @@ pub fn sanity(store: &dyn Storage, env: &Env) {
                 }
             }
 
-            if has_tokens {
+            if has_tokens || !shares.is_zero() {
                 computed_total_wallets += 1;
             }
         }
@@ -83,17 +83,10 @@ pub fn sanity(store: &dyn Storage, env: &Env) {
             assert_eq!(tokens.0, pool_size.0);
         }
 
-        // FIXME modify check to include in all wallets if they have a liquidity share
         assert_eq!(computed_total_wallets, total_wallets);
 
         for outcome in &market_outcomes {
             assert_eq!(computed_wallets[outcome.id.usize()], outcome.wallets);
         }
-    }
-}
-
-impl LpShare {
-    fn is_zero(self) -> bool {
-        self.0.is_zero()
     }
 }

--- a/contract/src/state.rs
+++ b/contract/src/state.rs
@@ -109,6 +109,8 @@ pub struct StoredMarket {
     pub total_wallets: u32,
     /// Total shares across all wallets
     pub lp_shares: LpShare,
+    /// Number of wallets holding LP shares
+    pub lp_wallets: u32,
 }
 
 impl StoredMarket {

--- a/contract/src/tests.rs
+++ b/contract/src/tests.rs
@@ -734,6 +734,7 @@ fn test_cpmm_buy_sell(pool_one in 1..1000u32, pool_two in 1..1000u32, buy in 2..
         house: Addr::unchecked("house"),
         total_wallets: 0,
         lp_shares: LpShare::zero(),
+        lp_wallets: 0,
     };
     let yes_id = OutcomeId::from(0);
     let yes_tokens = stored.buy(yes_id, buy, Decimal256::zero()).unwrap();

--- a/contract/src/types.rs
+++ b/contract/src/types.rs
@@ -238,6 +238,10 @@ impl LpShare {
     pub(crate) fn zero() -> LpShare {
         LpShare(Uint256::zero())
     }
+
+    pub fn is_zero(self) -> bool {
+        self.0.is_zero()
+    }
 }
 
 impl Display for LpShare {

--- a/frontend/src/api/queries/Market.ts
+++ b/frontend/src/api/queries/Market.ts
@@ -23,6 +23,7 @@ interface ResponseMarket {
   total_wallets: number
   pool_size: string
   lp_shares: string
+  lp_wallets: number
 }
 
 interface ResponseMarketOutcome {
@@ -47,6 +48,7 @@ interface Market {
   totalWallets: number
   poolSize: Coins
   lpShares: BigNumber
+  lpWallets: number
 }
 
 interface MarketOutcome {
@@ -85,6 +87,9 @@ const marketFromResponse = (response: ResponseMarket): Market => {
     totalWallets: response.total_wallets,
     poolSize: Coins.fromUnits(response.denom, response.pool_size),
     lpShares: BigNumber(response.lp_shares),
+    // Checking for missing data is just for testing with older contracts.
+    // That code can be removed in the future.
+    lpWallets: response.lp_wallets || 1,
   }
 }
 

--- a/frontend/src/features/MarketDetail/components/MarketOutcomes/index.tsx
+++ b/frontend/src/features/MarketDetail/components/MarketOutcomes/index.tsx
@@ -47,12 +47,23 @@ const MarketOutcomesContent = (props: { market: Market }) => {
             >
               {outcome.percentage.toFixed(1)}%
             </Typography>
+            <Typography
+              level="title-md"
+              textColor="text.secondary"
+              fontWeight={500}
+            >
+              {outcome.wallets} {outcome.wallets === 1 ? "holder" : "holders"}
+            </Typography>
           </Box>
         ))}
       </Stack>
       <Box sx={{ mt: 2 }}>
         <Typography level="body-md" textColor="text.secondary" fontWeight={600}>
           Prize pool size: {market.poolSize.toFormat(true)}
+        </Typography>
+        <Typography level="body-md" textColor="text.secondary">
+          {market.totalWallets}{" "}
+          {market.totalWallets === 1 ? "participant" : "participant"}
         </Typography>
       </Box>
     </>

--- a/frontend/src/features/MarketDetail/components/MyLiquidity/index.tsx
+++ b/frontend/src/features/MarketDetail/components/MyLiquidity/index.tsx
@@ -51,6 +51,9 @@ const MyLiquidityContent = (props: {
       <Typography>
         You own {poolPortion.times(100).toFixed(3)}% of the liquidity pool.
       </Typography>
+      <Typography>
+        {market.lpWallets} liquidity provider{market.lpWallets !== 1 && "s"}
+      </Typography>
       <Stack direction="row" alignItems="center" gap={4}>
         {market.possibleOutcomes.map((outcome) => (
           <Box key={outcome.id}>


### PR DESCRIPTION
Previously, if a wallet held LP shares but no tokens directly, it would not be included in the total wallets count. This change now includes LP-only wallets in the total wallet count.